### PR TITLE
Include tzdata as implicit runtime dependency.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN apk --no-cache add \
         libexecinfo \
         libexecinfo-dev \
         curl \
+        tzdata \
         wget && \
 # R build dependencies
     apk --no-cache add --virtual build-deps \


### PR DESCRIPTION
tidyr universe package `lubridate` depends on information in `/usr/share/zoneinfo` that is provided by the tzdata library added through apk.

This occurred in the R 3.* world (Greenline), but I wanted to propose introducing this into R 4.* containers while we're thinking about it.  And as something to do during a cloudformation deploy!